### PR TITLE
Fix latest news date mismatch across locales

### DIFF
--- a/static-site/content/en/news/372.md
+++ b/static-site/content/en/news/372.md
@@ -1,6 +1,6 @@
 ---
-title: Oct 2025 The Symbol Syndicate’s Docs Blogs
-description: Oct 2025 The Symbol Syndicate’s Docs Blogs
+title: Feb 2026 The Symbol Syndicate’s Docs Blogs
+description: Feb 2026 The Symbol Syndicate’s Docs Blogs
 createdAt: '2026-03-06T14:11:07.270Z'
 updatedAt: '2026-03-06T14:11:07.270Z'
 publishedAt: '2026-03-06T14:11:07.270Z'

--- a/static-site/content/ja/news/376.md
+++ b/static-site/content/ja/news/376.md
@@ -1,5 +1,5 @@
 ---
-title: Oct 2025 The Symbol Syndicate’s Docs Blogs
+title: Feb 2026 The Symbol Syndicate’s Docs Blogs
 description: 2026年2月のブログ（日本語訳）
 createdAt: '2026-03-06T14:11:07.270Z'
 updatedAt: '2026-03-06T14:11:07.270Z'

--- a/static-site/content/ko/news/373.md
+++ b/static-site/content/ko/news/373.md
@@ -1,5 +1,5 @@
 ---
-title: Oct 2025 The Symbol Syndicate’s Docs Blogs
+title: Feb 2026 The Symbol Syndicate’s Docs Blogs
 description: 2026년 2월 블로그는 여기에서 확인하실 수 있습니다.
 createdAt: '2026-03-06T14:11:07.270Z'
 updatedAt: '2026-03-06T14:11:07.270Z'

--- a/static-site/content/zh-hant-tw/news/375.md
+++ b/static-site/content/zh-hant-tw/news/375.md
@@ -1,5 +1,5 @@
 ---
-title: Oct 2025 The Symbol Syndicate’s Docs Blogs
+title: Feb 2026 The Symbol Syndicate’s Docs Blogs
 description: 2026 年 2月的部落格在這裡。
 createdAt: '2026-03-06T14:11:07.270Z'
 updatedAt: '2026-03-06T14:11:07.270Z'

--- a/static-site/content/zh/news/374.md
+++ b/static-site/content/zh/news/374.md
@@ -1,5 +1,5 @@
 ---
-title: Oct 2025 The Symbol Syndicate’s Docs Blogs
+title: Feb 2026 The Symbol Syndicate’s Docs Blogs
 description: 2026 年 2月的博客在这里。
 createdAt: '2026-03-06T14:11:07.270Z'
 updatedAt: '2026-03-06T14:11:07.270Z'


### PR DESCRIPTION
## Summary\n- fix incorrect month/year in frontmatter title for latest news articles across all locales\n- update English latest article description to match corrected Feb 2026 title\n\n## Files changed\n- static-site/content/en/news/372.md\n- static-site/content/ja/news/376.md\n- static-site/content/ko/news/373.md\n- static-site/content/zh/news/374.md\n- static-site/content/zh-hant-tw/news/375.md\n\n## Why\nLatest news cards render frontmatter title, so stale "Oct 2025" titles on newly published March 2026 entries caused wrong date text on the news page.