### PR TITLE
Add related site link to About section

### DIFF
--- a/static-site/content/i18n/en.json
+++ b/static-site/content/i18n/en.json
@@ -42,6 +42,8 @@
   "start_card4": "Information for developers",
   "about_title": "About Us",
   "about_body": "Symbol Community Web is run by members of the community. Meet the team behind the site.",
+  "about_related_site_label": "Another site run by the operators:",
+  "about_related_site_link_text": "Auto Research Skill",
   "footer_copyright": "© Symbol Community. All rights reserved.",
   "footer_links": {
     "docs": "Documentation",

--- a/static-site/content/i18n/ja.json
+++ b/static-site/content/i18n/ja.json
@@ -42,6 +42,8 @@
   "start_card4": "開発者向けの情報",
   "about_title": "運営チームについて",
   "about_body": "Symbol Community Web はコミュニティのメンバーによって運営されています。サイトを運営するチームを紹介します。",
+  "about_related_site_label": "この記事の運用者による他のサイト:",
+  "about_related_site_link_text": "Auto Research Skill",
   "footer_copyright": "© Symbol Community. All rights reserved.",
   "footer_links": {
     "docs": "ドキュメント",

--- a/static-site/content/i18n/ko.json
+++ b/static-site/content/i18n/ko.json
@@ -42,6 +42,8 @@
   "start_card4": "개발자 정보",
   "about_title": "소개",
   "about_body": "Symbol Community Web은 커뮤니티 회원들에 의해 운영됩니다. 사이트 뒤에 있는 팀을 만나보세요.",
+  "about_related_site_label": "운영자가 운영하는 다른 사이트:",
+  "about_related_site_link_text": "Auto Research Skill",
   "footer_copyright": "© Symbol Community. All rights reserved.",
   "footer_links": {
     "docs": "문서",

--- a/static-site/content/i18n/zh-hant-tw.json
+++ b/static-site/content/i18n/zh-hant-tw.json
@@ -42,6 +42,8 @@
   "start_card4": "開發者資訊",
   "about_title": "關於我們",
   "about_body": "Symbol Community Web 由社群成員運營。了解網站背後的團隊。",
+  "about_related_site_label": "營運者的其他網站:",
+  "about_related_site_link_text": "Auto Research Skill",
   "footer_copyright": "© Symbol Community. All rights reserved.",
   "footer_links": {
     "docs": "文檔",

--- a/static-site/content/i18n/zh.json
+++ b/static-site/content/i18n/zh.json
@@ -42,6 +42,8 @@
   "start_card4": "开发者信息",
   "about_title": "关于我们",
   "about_body": "Symbol Community Web 由社区成员运营。了解网站背后的团队。",
+  "about_related_site_label": "运营者的其他网站:",
+  "about_related_site_link_text": "Auto Research Skill",
   "footer_copyright": "© Symbol Community. All rights reserved.",
   "footer_links": {
     "docs": "文档",

--- a/static-site/scripts/build-site.ts
+++ b/static-site/scripts/build-site.ts
@@ -908,6 +908,15 @@ function renderHomePage(locale: Locale, i18n: I18n, news: Article[], community: 
       <div class="container">
         <h2 class="section-title">${escapeHtml(text(i18n, 'about_title', 'About this project'))}</h2>
         <p class="section-description">${escapeHtml(text(i18n, 'about_body', 'This website is maintained by community contributors.'))}</p>
+        <p class="section-description" style="margin-top:0.75rem;">
+          ${escapeHtml(text(i18n, 'about_related_site_label', 'Another site run by the operators:'))}
+          <a
+            class="inline-link"
+            href="https://ymuichiro.github.io/auto-research-skill/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >${escapeHtml(text(i18n, 'about_related_site_link_text', 'Auto Research Skill'))}</a>
+        </p>
         <p style="margin-top:1rem;">
           <a class="inline-link" href="https://github.com/symbol-blockchain-community/symbol-web" target="_blank" rel="noopener">${ui.editOnGitHub}</a>
         </p>


### PR DESCRIPTION
## Summary
- add a visible related-site link to the About section
- add localized labels for the related-site link across supported languages

## Testing
- not run locally because static-site dependencies are not installed in this environment