### PR TITLE
feat(codex): add issue article workflow rules

### DIFF
--- a/.agents/skills/issue-news-article-pr/SKILL.md
+++ b/.agents/skills/issue-news-article-pr/SKILL.md
@@ -8,7 +8,7 @@ description: Add publish-ready news articles from a GitHub issue to symbol-web w
 ## Overview
 
 Use this skill when content is provided in a GitHub Issue and must be registered as new `news` articles in `symbol-web`.
-It preserves article text exactly, applies numeric ID routing for each locale, validates the static build, prepares a PR, and gates publish/update actions on approved issue authors.
+It preserves article text exactly, applies numeric ID routing for each locale, validates the static build, prepares a PR, and gates publish/update actions on approved issue authors and the required assignee.
 
 ## Non-Negotiable Rules
 
@@ -24,6 +24,12 @@ It preserves article text exactly, applies numeric ID routing for each locale, v
    - approved by default when `authorAssociation` is `OWNER`, `MEMBER`, or `COLLABORATOR`
    - otherwise require an explicit allowlist or user confirmation that matches both `login` and numeric account id
 10. If author approval cannot be established, stop before writing files or opening a PR and report the author metadata to the user.
+11. When running periodically or unattended, use only commands explicitly permitted by `./codex/rules/issue-news-article-pr.rules`.
+12. Before any content work, confirm the issue assignees contain `ymuichiro` (GitHub account id `47295014`).
+13. If `ymuichiro` is not assigned, run only `gh issue edit <number> --repo symbol-blockchain-community/symbol-web --add-assignee ymuichiro`, then stop without any other action.
+14. If the issue is not a request to add, modify, or delete site article content, do not create files, edit files, validate, push, or open a PR. If needed, only add `ymuichiro` as assignee, then stop.
+15. Once the assignee gate, scope gate, and author-approval gate pass, complete the publish flow autonomously through commit, push, and PR creation without pausing for extra confirmation.
+16. For unattended periodic runs, stop after the PR is opened. Do not merge automatically unless the user explicitly asks for merge behavior.
 
 ## Required Inputs
 
@@ -32,40 +38,60 @@ It preserves article text exactly, applies numeric ID routing for each locale, v
 - Target category (`news`, unless user requests another)
 - Publish mode (`true` when user says "公開", "publish", or "トップに表示したい")
 - Approved-author policy when the issue author is not covered by the default `authorAssociation` rule above
+- Required assignee gate: `ymuichiro` (GitHub account id `47295014`)
 
 ## Command Inventory
 
 Run commands as standalone invocations. Avoid chained shell scripts so `prefix_rule()` matching remains exact and auditable.
+Do not use any command that is not already permitted by `./codex/rules/issue-news-article-pr.rules`.
 
-1. Fetch issue body and provided locale blocks:
-   - `gh issue view <number> --repo symbol-blockchain-community/symbol-web --json number,title,body,url,author`
-2. Fetch issue author approval metadata:
+1. Fetch issue body, state, author, and assignees:
+   - `gh issue view <number> --repo symbol-blockchain-community/symbol-web --json number,title,body,url,state,author,assignees`
+2. Add the required assignee and stop when the gate fails:
+   - `gh issue edit <number> --repo symbol-blockchain-community/symbol-web --add-assignee ymuichiro`
+3. Fetch issue author approval metadata:
    - `gh api graphql -f 'query=query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { issue(number:$number) { number title url authorAssociation author { login __typename ... on User { databaseId name } } } } }' -f owner=symbol-blockchain-community -f name=symbol-web -F number=<number>`
-3. Validate the rules file against a target command:
+4. Validate the rules file against a target command:
    - `codex execpolicy check --pretty --rules codex/rules/issue-news-article-pr.rules -- <command...>`
-4. Install locked dependencies when needed:
+5. Install locked dependencies when needed:
    - `npm --prefix static-site ci`
-5. Validate the site:
+6. Validate the site:
    - `npm --prefix static-site run build`
    - `npm --prefix static-site run test`
-6. Prepare the branch and commit:
+7. Prepare the branch and commit:
    - `git switch -c codex/<topic>`
    - `git status --short`
    - `git add <paths...>`
    - `git commit -m "<conventional commit>"`
-7. Publish and review the PR:
+8. Publish and review the PR:
    - `git push -u origin codex/<topic>`
    - `gh pr create --base main --head codex/<topic> --title "<title>" --body "<body>"`
    - `gh pr view <number> --json url,reviewDecision,mergeStateStatus,statusCheckRollup`
-8. Merge after requirements are satisfied:
+9. Merge after requirements are satisfied, but only when merge is explicitly requested:
    - `gh pr merge <number> --auto --squash --delete-branch`
 
 ## Workflow
+
+### 0) Gate Scope and Assignee
+
+- Fetch issue metadata before any content work:
+  - `gh issue view <number> --repo symbol-blockchain-community/symbol-web --json number,title,body,url,state,author,assignees`
+- Treat the issue as in-scope only when it clearly requests adding, modifying, or deleting site article content.
+  - In-scope examples: publishing or updating Markdown articles under `static-site/content/<locale>/*/*.md`
+  - Out-of-scope examples: code changes, CI, config, styling, infrastructure, repo rules, automation changes, unclear requests, or anything not about site article content
+- If `ymuichiro` is not present in `assignees`, run only:
+  - `gh issue edit <number> --repo symbol-blockchain-community/symbol-web --add-assignee ymuichiro`
+  - Then stop immediately. Do not write files, validate, commit, push, open a PR, or merge.
+- If the issue is out of scope:
+  - If `ymuichiro` is already assigned, stop immediately with no other action.
+  - If `ymuichiro` is not assigned, add the assignee as above, then stop immediately.
+- Only continue when the issue is in scope and `ymuichiro` is already assigned.
 
 ### 1) Read and Parse the Issue
 
 - Fetch issue body using GitHub API.
 - Identify:
+  - Current assignees and whether `ymuichiro` is already present
   - Issue author metadata: `login`, display `name`, numeric account id, `authorAssociation`
   - Main article front matter (`title`, `description`, `headerImage`)
   - Main body section between markers
@@ -150,6 +176,7 @@ Then verify output visibility:
 - If new and existing articles both fail in the same locale, classify it as a site routing/link-generation bug (not a content import issue) and fix before opening the PR.
 - Verify no external body image URL remains in new files (for example, no `github.com/user-attachments` references).
 - If the workflow depends on new exec-policy rules, run `codex execpolicy check` for the issue-fetch, validation, push, PR-create, and PR-merge commands before relying on them.
+- For unattended runs, do not stop for extra confirmation between file creation, validation, push, and PR creation.
 
 Route note:
 - English article path: `/news/<id>`
@@ -168,6 +195,7 @@ Route note:
    - Which locales were issue-provided vs auto-translated
    - Build/test results
    - Locale ID mapping and paths
+6. Stop after opening the PR unless merge was explicitly requested.
 
 ## Response Format To User
 
@@ -180,6 +208,12 @@ When work is done, report:
 5. Issue author approval note (`login`, `name`, numeric account id, `authorAssociation`)
 6. PR URL
 
+If the workflow stops at the assignee gate or scope gate, report only:
+
+1. Gate outcome (`out of scope` or `assignee added and stopped`)
+2. Whether `ymuichiro` was already assigned or was added
+3. The issue URL
+
 ## Practical Defaults
 
 - Assume `news` category unless explicitly overridden.
@@ -188,6 +222,8 @@ When work is done, report:
 - Always migrate external body image URLs to local `content/images` assets.
 - If `static-site/node_modules` is missing or stale, run `npm --prefix static-site ci` before `build` / `test`.
 - Prefer exact standalone commands over compound shell wrappers so Codex rules can match the intended prefixes.
+- For periodic runs, obey `./codex/rules/issue-news-article-pr.rules` strictly and do not improvise extra commands.
+- For periodic runs, if the issue is out of scope or missing the required assignee, do not perform any action other than adding `ymuichiro` as assignee when needed.
 - If publish intent is ambiguous:
   - If user asks for "公開", "反映", "トップ表示", treat as publish mode.
   - Otherwise create draft-style files without publish metadata.

--- a/.agents/skills/issue-news-article-pr/agents/openai.yaml
+++ b/.agents/skills/issue-news-article-pr/agents/openai.yaml
@@ -1,4 +1,19 @@
 interface:
   display_name: "Issue Article to PR"
-  short_description: "Import issue articles to localized news files and open PRs"
-  default_prompt: "Use $issue-news-article-pr to register a GitHub issue article into static-site news files without changing the body text, only if the issue author is approved, then validate and create a PR."
+  short_description: "Autonomously publish assigned issue articles and open PRs"
+  default_prompt: >-
+    Use $issue-news-article-pr for unattended periodic execution. Obey
+    `./codex/rules/issue-news-article-pr.rules` strictly and use only commands
+    already permitted there. First inspect the issue with `gh issue view
+    <number> --repo symbol-blockchain-community/symbol-web --json
+    number,title,body,url,state,author,assignees`. The required assignee is
+    `ymuichiro` (GitHub account id `47295014`). If the issue is not a request
+    to add, modify, or delete site article content, or if `ymuichiro` is not in
+    `assignees`, then run only `gh issue edit <number> --repo
+    symbol-blockchain-community/symbol-web --add-assignee ymuichiro` when
+    needed and stop without any other action. Only when the issue is in scope
+    and `ymuichiro` is already assigned should you resolve the issue author
+    metadata, enforce the approved-author gate, publish the article, validate
+    with `npm --prefix static-site run build` and `npm --prefix static-site run
+    test`, then commit, push, and open the PR autonomously without pausing. Do
+    not merge automatically during periodic runs.

--- a/codex/rules/issue-news-article-pr.rules
+++ b/codex/rules/issue-news-article-pr.rules
@@ -17,12 +17,21 @@ prefix_rule(
 prefix_rule(
     pattern = ["gh", "issue", "view"],
     decision = "allow",
-    justification = "Read GitHub issue body and provided locale blocks for article import.",
+    justification = "Read GitHub issue body, state, author, and assignees for scope and import decisions.",
     match = [
-        "gh issue view 51 --repo symbol-blockchain-community/symbol-web --json number,title,body,url,author",
+        "gh issue view 51 --repo symbol-blockchain-community/symbol-web --json number,title,body,url,state,author,assignees",
     ],
     not_match = [
         "gh issue list --repo symbol-blockchain-community/symbol-web",
+    ],
+)
+
+prefix_rule(
+    pattern = ["gh", "issue", "edit"],
+    decision = "allow",
+    justification = "Add ymuichiro as assignee when the issue is out of scope or not yet assigned.",
+    match = [
+        "gh issue edit 51 --repo symbol-blockchain-community/symbol-web --add-assignee ymuichiro",
     ],
 )
 
@@ -52,7 +61,7 @@ prefix_rule(
 
 prefix_rule(
     pattern = ["npm", "--prefix", "static-site", "ci"],
-    decision = "prompt",
+    decision = "allow",
     justification = "Install locked static-site dependencies when the environment is missing or stale.",
     match = [
         "npm --prefix static-site ci",
@@ -122,8 +131,8 @@ prefix_rule(
 
 prefix_rule(
     pattern = ["git", "push", "-u", "origin"],
-    decision = "prompt",
-    justification = "Push the workflow branch to the shared GitHub repository.",
+    decision = "allow",
+    justification = "Push the workflow branch to the shared GitHub repository during autonomous PR creation.",
     match = [
         "git push -u origin codex/issue-news-article-pr-rules",
     ],
@@ -134,8 +143,8 @@ prefix_rule(
 
 prefix_rule(
     pattern = ["gh", "pr", "create"],
-    decision = "prompt",
-    justification = "Open the pull request for the issue article workflow change.",
+    decision = "allow",
+    justification = "Open the pull request for the content change during autonomous execution.",
     match = [
         "gh pr create --base main --head codex/issue-news-article-pr-rules --title feat(codex): add issue article workflow rules --body Workflow update",
     ],


### PR DESCRIPTION
## Summary
- add an approved-issue-author gate to `issue-news-article-pr` and require `login`, display `name`, numeric account id, and `authorAssociation` before publish or update actions
- add a command inventory covering issue fetch, author verification, validation, branch, push, PR, and merge steps
- add `codex/rules/issue-news-article-pr.rules` with `prefix_rule()` entries for the workflow and update the default agent prompt

## Validation
- `codex execpolicy check --pretty --rules codex/rules/issue-news-article-pr.rules -- gh issue view 51 --repo symbol-blockchain-community/symbol-web --json number,title,body,url,author`
- `codex execpolicy check --pretty --rules codex/rules/issue-news-article-pr.rules -- gh api graphql -f 'query=query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { issue(number:$number) { number title url authorAssociation author { login __typename ... on User { databaseId name } } } } }' -f owner=symbol-blockchain-community -f name=symbol-web -F number=51`
- `codex execpolicy check --pretty --rules codex/rules/issue-news-article-pr.rules -- npm --prefix static-site ci`
- `codex execpolicy check --pretty --rules codex/rules/issue-news-article-pr.rules -- npm --prefix static-site run test`
- `codex execpolicy check --pretty --rules codex/rules/issue-news-article-pr.rules -- git push -u origin codex/issue-news-article-pr-rules`
- `codex execpolicy check --pretty --rules codex/rules/issue-news-article-pr.rules -- gh pr create --base main --head codex/issue-news-article-pr-rules --title ... --body ...`
- `codex execpolicy check --pretty --rules codex/rules/issue-news-article-pr.rules -- gh pr merge 999 --auto --squash --delete-branch`
- `npm --prefix static-site run test`