### PR TITLE
feat(content): add blockchain expo spring community articles from issue #76

### DIFF
--- a/static-site/content/en/community/550.md
+++ b/static-site/content/en/community/550.md
@@ -1,0 +1,100 @@
+---
+title: '10 companies and organizations using the Symbol blockchain to exhibit at the 7th Blockchain EXPO Spring'
+description: 'Ten companies and organizations using the Symbol blockchain will exhibit at the 7th Blockchain EXPO Spring.'
+createdAt: '2026-04-13T00:00:00Z'
+updatedAt: '2026-04-13T00:00:00Z'
+publishedAt: '2026-04-13T00:00:00Z'
+headerImage: https://github.com/user-attachments/assets/3e91b72d-9f93-457d-9b42-08c0ff70f5bc
+localizations:
+  - id: 551
+    locale: ja-JP
+  - id: 552
+    locale: ko
+  - id: 553
+    locale: zh
+  - id: 554
+    locale: zh-Hant-TW
+---
+## 10 companies and organizations using the Symbol blockchain to exhibit at the 7th Blockchain EXPO Spring
+
+<img width="1280" height="720" alt="Image" src="https://github.com/user-attachments/assets/9984ccf0-2de4-4a59-a492-028e55e04eae" />
+
+Event: [7th Blockchain EXPO [Spring]](https://www.nextech-week.jp/hub/ja-jp/visit/bc.html)
+Date and time: Wednesday, April 15, 2026 to Friday, April 17, 2026, 10:00-17:00
+Venue: Tokyo Big Sight West Exhibition Halls
+Admission: Free (advance registration required)
+#### 7th Blockchain EXPO [Spring] Official Website (overview here)
+> [NexTech Week](https://www.nextech-week.jp/hub/ja-jp/visit/bc.html)
+
+#### Advance visitor registration
+Registration (free) is required to enter Blockchain EXPO.
+Please obtain a visitor badge at the following URL before attending.
+
+> URL：https://www.nextech-week.jp/spring/ja-jp/register.html?code=1611458530170798-ENW
+>
+
+At "NexTech Week 2026, 7th Blockchain EXPO Spring," one of Japan's largest events for encountering the latest blockchain technologies and services, a total of 10 companies and organizations centered on NEMTUS, the NPO that promotes the spread and development of blockchain technology as well as NEM and Symbol blockchain technology, will jointly exhibit businesses and initiatives that use Symbol.
+
+This joint exhibit will introduce the products and services of companies and organizations using the Symbol blockchain in one place, comprehensively showcasing Symbol's technical potential and the value of its social implementation while exploring adoption and collaboration opportunities for new and existing businesses using Symbol.
+
+AI EXPO, Quantum Computing EXPO, AI Era Human Resources and Organizational Reform EXPO, and Humanoid Robot EXPO will also be held at the same time, creating an excellent opportunity to communicate the appeal of Symbol to many business professionals interested in the latest digital technologies.
+
+## Exhibiting companies and organizations making use of the Symbol blockchain
+
+* [NPO NEM Technology Dissemination Association NEMTUS](https://nemtus.com)
+* [Atomos-Seed LLC](https://atomosseed.com)
+* [Food NFT Consortium](https://food-nft.io)
+* [Grape Co., Ltd.](https://grape.ne.jp)
+* [Japan General Research Center Co., Ltd.](https://jgrec.jp)
+* [Keisei Solution Co., Ltd.](http://keisei-s.co.jp)
+* [HealthCareGate Co., Ltd.](https://healthcaregate.co.jp)
+* [Palette Link Okinawa LLC](https://plo.llc)
+* [Netsujo Inc.](https://netsujo.jp)
+* [Kansai Healthcare Science Informatics Association](https://www.khsi.or.jp)
+
+## A Symbol use case will appear in a case study seminar
+
+### Blockchain Case Studies 9
+Date: Friday, April 17, 2026, 10:20-11:00
+Speaker: [Food NFT Consortium](https://food-nft.io)
+"Declaration of the Nation of Washoku Republic! Washoku's Web3 process economy and the Nodai community"
+* Seminar venue: "Blockchain Case Studies" venue next to the Web3 World area
+
+![Image](https://github.com/user-attachments/assets/494a97bc-7479-48b2-9d84-8b5a6f30773c)
+
+This session will introduce the comprehensive Web3 process-economy solution "Washoku Republic," designed to preserve Japan's unique food culture, pass it on to the next generation, and continue sharing it with the world. It will also feature experts, front-line producers, and community representatives discussing Japanese agriculture, one of the important elements that supports washoku, and the agricultural university community that continues to sustain it.
+* Detailed explanation of the "Washoku Republic" comprehensive Web3 process-economy solution
+* The current state and future of Japanese agriculture and the Nodai community
+* Advance distribution of the "Washoku Republic" white paper
+
+![Image](https://github.com/user-attachments/assets/db1d62ae-0a03-44ff-880e-cf782cf8dce0)
+
+### Speakers
+* Hiroyuki Goto (Moderator)
+Food NFT Consortium Co-Chair
+Representative, Atomos-Seed LLC
+Chairperson, NPO NEM Technology Dissemination Association NEMTUS
+* Nao Shinohara
+Freelance
+Product development consulting / project support
+Former product development staff at Tohato Co., Ltd.
+Community activities with CNP (CryptoNinja Partners)
+* Satoko Takenaka
+Tabemono no Koe / Washoku Producer
+Former NHK program director
+Holds Le Cordon Bleu Japanese Cuisine Diploma
+Leads "Washoku x Process Economy"
+* Takehiro Ishikawa
+Representative of the Nodai community
+Graduate of Tokyo University of Agriculture
+Personal nutritionist, health management advisor
+Expert fasting meister
+
+#### Advance registration is required to attend the "Blockchain Case Studies 9" seminar
+Please access the seminar registration site from the URL below and apply using the orange "Select this seminar" button for "BC-9 Blockchain Case Studies 9."
+
+> URL：https://biz.q-pass.jp/f/11988/ntw26sp/seminar_register#seminar111511
+
+### Related links
+* [“Washoku Republic” project launched: a Web3 process economy that turns the “process” of washoku into value](https://symbol-community.com/ja/community/541.html)
+* [“Mini Republic Story” project launched](https://symbol-community.com/ja/community/546.html)

--- a/static-site/content/ja/community/551.md
+++ b/static-site/content/ja/community/551.md
@@ -1,0 +1,100 @@
+---
+title: '第7回ブロックチェーンEXPO春 Symbolブロックチェーンを活用する10の企業・団体が出展'
+description: '第7回ブロックチェーンEXPO春 Symbolブロックチェーンを活用する10の企業・団体が出展します'
+createdAt: '2026-04-13T00:00:00Z'
+updatedAt: '2026-04-13T00:00:00Z'
+publishedAt: '2026-04-13T00:00:00Z'
+headerImage: https://github.com/user-attachments/assets/3e91b72d-9f93-457d-9b42-08c0ff70f5bc
+localizations:
+  - id: 550
+    locale: en
+  - id: 552
+    locale: ko
+  - id: 553
+    locale: zh
+  - id: 554
+    locale: zh-Hant-TW
+---
+## 第7回ブロックチェーンEXPO春 Symbolブロックチェーンを活用する10の企業・団体が出展します
+
+<img width="1280" height="720" alt="Image" src="https://github.com/user-attachments/assets/9984ccf0-2de4-4a59-a492-028e55e04eae" />
+
+イベント：[第7回ブロックチェーンEXPO【春】](https://www.nextech-week.jp/hub/ja-jp/visit/bc.html)
+日時：2026年4月15日(水)~ 4月17日(金)10:00〜17:00
+会場：東京ビッグサイト 西展示棟
+来場費用：無料（要事前登録）
+#### 第7回ブロックチェーンEXPO【春】公式HP(概要はこちらから)
+> [NexTech Week](https://www.nextech-week.jp/hub/ja-jp/visit/bc.html)
+
+#### 来場事前登録
+ブロックチェーンEXPO 入場には登録(無料)が必要です。
+来場事前登録は、次のURLより「来場者バッジ」を取得し、ご利用ください。
+
+> URL：https://www.nextech-week.jp/spring/ja-jp/register.html?code=1611458530170798-ENW
+>
+
+日本最大級の最新のブロックチェーン技術やサービスに出会えるイベント、「NexTech Week 2026 第7回ブロックチェーンEXPO春」に、ブロックチェーン技術およびNEM、Symbolブロックチェーンの技術の普及や発展を促進するNPO法人NEM技術普及推進会NEMTUSを中心に、 Symbol を活用したビジネスを展開している企業や団体合計10団体で共同出展します。
+
+本出展では、Symbolブロックチェーンを利活用している企業や団体のプロダクトやサービスを一挙に紹介し、Symbolの技術的ポテンシャルや、社会実装の価値を包括的にアピールし、Symbolを活用した新規・既存ビジネスへの導入や協業を模索します。
+
+また、AI・人工知能 EXPO / 量子コンピューティング EXPO / AI時代の人材・組織改革EXPO / ヒューマノイドロボットEXPO が同時開催されますので 、最新デジタル技術に関心を持つ多くのビジネスパーソンにSymbolの魅力を伝えることができる素晴らしい機会となることが期待されています。
+
+## Symbolブロックチェーンを利活用している出展企業・団体
+
+* [NPO法人NEM技術普及推進会NEMTUS](https://nemtus.com)
+* [Atomos-Seed合同会社](https://atomosseed.com)
+* [フードNFTコンソーシアム](https://food-nft.io)
+* [ぶどう株式会社](https://grape.ne.jp)
+* [国立日本総合研究センター株式会社](https://jgrec.jp)
+* [株式会社慶成ソリューション](http://keisei-s.co.jp)
+* [株式会社HealthCareGate](https://healthcaregate.co.jp)
+* [合同会社パレットリンク沖縄](https://plo.llc)
+* [Netsujo株式会社](https://netsujo.jp)
+* [一般社団法人関西ヘルスケアサイエンスインフォマティクス](https://www.khsi.or.jp)
+
+## 事例セミナーにSymbolの活用実例が登場
+
+### Blockchain Case Studies 9
+日程：2026年4月17日(金) 10:20〜11:00
+登壇：[フードNFTコンソーシアム](https://food-nft.io)
+「和食共和国」建国宣言！和食のWeb3型プロセスエコノミーと農大コミュニティー
+※セミナー会場：Web3 Worldエリア隣接の「Blockchain Case Studies」会場
+
+![Image](https://github.com/user-attachments/assets/494a97bc-7479-48b2-9d84-8b5a6f30773c)
+
+日本独自の食文化を保存しながら次世代へ継承し、世界へ発信し続けるための、和食のWeb3型プロセスエコノミー総合ソリューション「和食共和国」について、そして和食の重要な構成要素の一つである日本の農業や、それらを支え続ける農大コミュニティーについて、専門家や第一線のプロデューサー、コミュニティー代表を交え、ご紹介します。
+* 和食のWeb3型プロセスエコノミー総合ソリューション「和食共和国」の詳細解説
+* 日本の農業と農大コミュニティーの現在地点とこれからについて
+* 「和食共和国」ホワイトペーパー先行配布
+
+![Image](https://github.com/user-attachments/assets/db1d62ae-0a03-44ff-880e-cf782cf8dce0)
+
+### 登壇者
+* 後藤 博之 (司会進行)
+フードNFTコンソーシアム　共同会長
+Atomos-Seed合同会社　代表
+NPO法人NEM技術普及推進会NEMTUS　理事長
+* 篠原 奈央
+フリーランス
+商品開発コンサルティング／企画支援
+元株式会社東ハト商品開発
+CNP(CryptoNinja Partners)コミュニティ活動
+* 竹中 聰子
+たべもののこえ 和食プロデューサー
+元NHK番組ディレクター
+コルドンブルー日本料理ディプロム取得
+「和食×プロセスエコノミー」主導
+* 石川 威弘
+農大コミュニティー代表
+東京農業大学卒業
+パーソナル栄養士、健康経営アドバイザー
+エキスパートファスティングマイスター
+
+#### 事例セミナー「Blockchain Case Studies 9」への参加は事前登録が必要です
+下記URLから事例セミナー 参加登録サイトへアクセスして、「BC-9　Blockchain Case Studies 9 」の【このセミナーを選択】ボタン(オレンジ色のボタン)からお申し込みください。
+
+> URL：https://biz.q-pass.jp/f/11988/ntw26sp/seminar_register#seminar111511
+
+### 関連リンク
+* [｢和食共和国｣プロジェクト始動｜和食の｢過程｣を価値化するWeb3型プロセスエコノミー](https://symbol-community.com/ja/community/541.html)
+* [「ミニ共和国物語」プロジェクト始動](https://symbol-community.com/ja/community/546.html)

--- a/static-site/content/ko/community/552.md
+++ b/static-site/content/ko/community/552.md
@@ -1,0 +1,102 @@
+---
+title: '제7회 블록체인 EXPO 봄, Symbol 블록체인을 활용하는 10개 기업 및 단체가 출전'
+description: '제7회 블록체인 EXPO 봄에 Symbol 블록체인을 활용하는 10개 기업 및 단체가 출전합니다.'
+createdAt: '2026-04-13T00:00:00Z'
+updatedAt: '2026-04-13T00:00:00Z'
+publishedAt: '2026-04-13T00:00:00Z'
+headerImage: https://github.com/user-attachments/assets/3e91b72d-9f93-457d-9b42-08c0ff70f5bc
+localizations:
+  - id: 550
+    locale: en
+  - id: 551
+    locale: ja-JP
+  - id: 553
+    locale: zh
+  - id: 554
+    locale: zh-Hant-TW
+---
+This page is a machine translation of the English text. Please contact `faunsu https://twitter.com/faunsu19000` or `symbol-community.com/community` for language proofreading of articles.
+
+## 제7회 블록체인 EXPO 봄, Symbol 블록체인을 활용하는 10개 기업 및 단체가 출전합니다
+
+<img width="1280" height="720" alt="Image" src="https://github.com/user-attachments/assets/9984ccf0-2de4-4a59-a492-028e55e04eae" />
+
+이벤트: [제7회 블록체인 EXPO【봄】](https://www.nextech-week.jp/hub/ja-jp/visit/bc.html)
+일시: 2026년 4월 15일(수)~ 4월 17일(금) 10:00~17:00
+장소: 도쿄 빅사이트 서전시장
+방문 비용: 무료(사전 등록 필요)
+#### 제7회 블록체인 EXPO【봄】 공식 홈페이지(개요는 여기에서)
+> [NexTech Week](https://www.nextech-week.jp/hub/ja-jp/visit/bc.html)
+
+#### 방문 사전 등록
+블록체인 EXPO 입장에는 등록(무료)이 필요합니다.
+다음 URL에서 "방문자 배지"를 발급받아 이용해 주십시오.
+
+> URL：https://www.nextech-week.jp/spring/ja-jp/register.html?code=1611458530170798-ENW
+>
+
+일본 최대급 규모로 최신 블록체인 기술과 서비스를 만날 수 있는 행사인 "NexTech Week 2026 제7회 블록체인 EXPO 봄"에 블록체인 기술과 NEM, Symbol 블록체인 기술의 보급과 발전을 촉진하는 NPO 법인 NEM 기술 보급 추진회 NEMTUS를 중심으로, Symbol을 활용한 비즈니스를 전개하는 기업 및 단체 총 10곳이 공동 출전합니다.
+
+이번 출전에서는 Symbol 블록체인을 활용하는 기업 및 단체의 제품과 서비스를 한자리에서 소개하고, Symbol의 기술적 잠재력과 사회 구현의 가치를 종합적으로 어필하며, Symbol을 활용한 신규 및 기존 비즈니스 도입과 협업 가능성을 모색합니다.
+
+또한 AI·인공지능 EXPO / 양자 컴퓨팅 EXPO / AI 시대의 인재·조직 개혁 EXPO / 휴머노이드 로봇 EXPO도 동시에 개최되어, 최신 디지털 기술에 관심 있는 많은 비즈니스 관계자들에게 Symbol의 매력을 전할 수 있는 훌륭한 기회가 될 것으로 기대됩니다.
+
+## Symbol 블록체인을 활용하고 있는 출전 기업·단체
+
+* [NPO법인 NEM기술보급추진회 NEMTUS](https://nemtus.com)
+* [Atomos-Seed 합동회사](https://atomosseed.com)
+* [푸드 NFT 컨소시엄](https://food-nft.io)
+* [부도 주식회사](https://grape.ne.jp)
+* [국립일본종합연구센터 주식회사](https://jgrec.jp)
+* [게이세이 솔루션 주식회사](http://keisei-s.co.jp)
+* [주식회사 HealthCareGate](https://healthcaregate.co.jp)
+* [합동회사 팔레트링크 오키나와](https://plo.llc)
+* [Netsujo 주식회사](https://netsujo.jp)
+* [일반사단법인 간사이 헬스케어 사이언스 인포매틱스](https://www.khsi.or.jp)
+
+## 사례 세미나에 Symbol 활용 사례가 등장
+
+### Blockchain Case Studies 9
+일정: 2026년 4월 17일(금) 10:20~11:00
+등단: [푸드 NFT 컨소시엄](https://food-nft.io)
+"와쇼쿠 공화국" 건국 선언! 와쇼쿠의 Web3형 프로세스 이코노미와 농대 커뮤니티
+* 세미나 장소: Web3 World 구역 인접 "Blockchain Case Studies" 회장
+
+![Image](https://github.com/user-attachments/assets/494a97bc-7479-48b2-9d84-8b5a6f30773c)
+
+일본 고유의 식문화를 보존하면서 다음 세대로 계승하고 세계에 계속 발신하기 위한 와쇼쿠의 Web3형 프로세스 이코노미 종합 솔루션 "와쇼쿠 공화국"과, 와쇼쿠의 중요한 구성 요소 중 하나인 일본 농업 및 그것을 지탱하는 농대 커뮤니티에 대해 전문가와 현장 프로듀서, 커뮤니티 대표를 모시고 소개합니다.
+* 와쇼쿠의 Web3형 프로세스 이코노미 종합 솔루션 "와쇼쿠 공화국" 상세 해설
+* 일본 농업과 농대 커뮤니티의 현재와 앞으로
+* "와쇼쿠 공화국" 화이트페이퍼 선행 배포
+
+![Image](https://github.com/user-attachments/assets/db1d62ae-0a03-44ff-880e-cf782cf8dce0)
+
+### 발표자
+* 고토 히로유키 (사회 진행)
+푸드 NFT 컨소시엄 공동회장
+Atomos-Seed 합동회사 대표
+NPO법인 NEM기술보급추진회 NEMTUS 이사장
+* 시노하라 나오
+프리랜서
+상품 개발 컨설팅 / 기획 지원
+전 주식회사 도하토 상품 개발
+CNP(CryptoNinja Partners) 커뮤니티 활동
+* 다케나카 사토코
+다베모노노코에 와쇼쿠 프로듀서
+전 NHK 프로그램 디렉터
+르 코르동 블루 일본요리 디플로마 취득
+"와쇼쿠 × 프로세스 이코노미" 주도
+* 이시카와 다케히로
+농대 커뮤니티 대표
+도쿄농업대학 졸업
+퍼스널 영양사, 건강경영 어드바이저
+엑스퍼트 패스팅 마이스터
+
+#### 사례 세미나 "Blockchain Case Studies 9" 참가에는 사전 등록이 필요합니다
+아래 URL에서 사례 세미나 참가 등록 사이트에 접속한 뒤, "BC-9 Blockchain Case Studies 9"의 【이 세미나 선택】 버튼(주황색 버튼)으로 신청해 주십시오.
+
+> URL：https://biz.q-pass.jp/f/11988/ntw26sp/seminar_register#seminar111511
+
+### 관련 링크
+* [「와쇼쿠 공화국」 프로젝트 시작 | 와쇼쿠의 「과정」을 가치화하는 Web3형 프로세스 이코노미](https://symbol-community.com/ja/community/541.html)
+* [「미니 공화국 이야기」 프로젝트 시작](https://symbol-community.com/ja/community/546.html)

--- a/static-site/content/zh-hant-tw/community/554.md
+++ b/static-site/content/zh-hant-tw/community/554.md
@@ -1,0 +1,102 @@
+---
+title: '第7屆區塊鏈EXPO春季展將有10家活用Symbol區塊鏈的企業與團體參展'
+description: '第7屆區塊鏈EXPO春季展將有10家活用Symbol區塊鏈的企業與團體參展。'
+createdAt: '2026-04-13T00:00:00Z'
+updatedAt: '2026-04-13T00:00:00Z'
+publishedAt: '2026-04-13T00:00:00Z'
+headerImage: https://github.com/user-attachments/assets/3e91b72d-9f93-457d-9b42-08c0ff70f5bc
+localizations:
+  - id: 550
+    locale: en
+  - id: 551
+    locale: ja-JP
+  - id: 552
+    locale: ko
+  - id: 553
+    locale: zh
+---
+This page is a machine translation of the English text. Please contact `faunsu https://twitter.com/faunsu19000` or `symbol-community.com/community` for language proofreading of articles.
+
+## 第7屆區塊鏈EXPO春季展將有10家活用Symbol區塊鏈的企業與團體參展
+
+<img width="1280" height="720" alt="Image" src="https://github.com/user-attachments/assets/9984ccf0-2de4-4a59-a492-028e55e04eae" />
+
+活動：[第7屆區塊鏈EXPO【春】](https://www.nextech-week.jp/hub/ja-jp/visit/bc.html)
+時間：2026年4月15日(週三)至4月17日(週五) 10:00-17:00
+會場：東京Big Sight西展示棟
+入場費用：免費(需事前登錄)
+#### 第7屆區塊鏈EXPO【春】官方網站(概要請見此處)
+> [NexTech Week](https://www.nextech-week.jp/hub/ja-jp/visit/bc.html)
+
+#### 來場事前登錄
+進入區塊鏈EXPO需要免費登錄。
+請由下列URL取得「來場者徽章」後使用。
+
+> URL：https://www.nextech-week.jp/spring/ja-jp/register.html?code=1611458530170798-ENW
+>
+
+在日本最大規模之一、可接觸最新區塊鏈技術與服務的活動「NexTech Week 2026 第7屆區塊鏈EXPO春季展」上，將以推動區塊鏈技術以及NEM、Symbol區塊鏈技術普及與發展的NPO法人NEM技術普及推進會NEMTUS為中心，由共計10家展開Symbol相關業務的企業與團體共同參展。
+
+本次參展將集中介紹活用Symbol區塊鏈的企業與團體所提供的產品與服務，全面展現Symbol的技術潛力與社會實裝價值，並探索將Symbol導入新舊業務與協業的可能性。
+
+另外，AI・人工智慧 EXPO、量子運算 EXPO、AI時代的人才與組織改革EXPO、仿人機器人EXPO也將同時舉辦，預期這將成為向眾多對最新數位技術感興趣的商務人士傳達Symbol魅力的絕佳機會。
+
+## 活用Symbol區塊鏈的參展企業與團體
+
+* [NPO法人NEM技術普及推進會NEMTUS](https://nemtus.com)
+* [Atomos-Seed合同會社](https://atomosseed.com)
+* [Food NFT Consortium](https://food-nft.io)
+* [ぶどう株式會社](https://grape.ne.jp)
+* [國立日本綜合研究中心株式會社](https://jgrec.jp)
+* [慶成解決方案株式會社](http://keisei-s.co.jp)
+* [HealthCareGate株式會社](https://healthcaregate.co.jp)
+* [Palette Link Okinawa合同會社](https://plo.llc)
+* [Netsujo株式會社](https://netsujo.jp)
+* [關西Healthcare Science Informatics一般社團法人](https://www.khsi.or.jp)
+
+## Symbol的活用案例將在案例研討會中登場
+
+### Blockchain Case Studies 9
+日期：2026年4月17日(週五) 10:20-11:00
+登壇：[Food NFT Consortium](https://food-nft.io)
+「和食共和國」建國宣言！和食的Web3型流程經濟與農大社群
+* 研討會會場：位於Web3 World區域旁的「Blockchain Case Studies」會場
+
+![Image](https://github.com/user-attachments/assets/494a97bc-7479-48b2-9d84-8b5a6f30773c)
+
+本場將介紹致力於保存日本獨有飲食文化、傳承給下一代並持續向世界發信的和食Web3型流程經濟綜合解決方案「和食共和國」，以及作為和食重要構成要素之一的日本農業與持續支撐其發展的農大社群，並邀請專家、第一線製作人與社群代表共同分享。
+* 「和食共和國」Web3型流程經濟綜合解決方案詳細解說
+* 日本農業與農大社群的現在與未來
+* 「和食共和國」白皮書搶先發放
+
+![Image](https://github.com/user-attachments/assets/db1d62ae-0a03-44ff-880e-cf782cf8dce0)
+
+### 登壇者
+* 後藤博之（主持）
+Food NFT Consortium 共同會長
+Atomos-Seed合同會社 代表
+NPO法人NEM技術普及推進會NEMTUS 理事長
+* 篠原奈央
+自由工作者
+商品開發顧問／企劃支援
+前株式會社東鳩商品開發
+CNP(CryptoNinja Partners)社群活動
+* 竹中聰子
+たべもののこえ 和食製作人
+前NHK節目導演
+取得藍帶日本料理文憑
+主導「和食×流程經濟」
+* 石川威弘
+農大社群代表
+東京農業大學畢業
+個人營養師、健康經營顧問
+專家級斷食大師
+
+#### 參加「Blockchain Case Studies 9」案例研討會需要事前登錄
+請由下方URL進入案例研討會報名網站，並透過「BC-9 Blockchain Case Studies 9」的【選擇此研討會】按鈕(橘色按鈕)完成報名。
+
+> URL：https://biz.q-pass.jp/f/11988/ntw26sp/seminar_register#seminar111511
+
+### 相關連結
+* [「和食共和國」專案啟動｜將和食「過程」價值化的Web3型流程經濟](https://symbol-community.com/ja/community/541.html)
+* [「迷你共和國物語」專案啟動](https://symbol-community.com/ja/community/546.html)

--- a/static-site/content/zh/community/553.md
+++ b/static-site/content/zh/community/553.md
@@ -1,0 +1,102 @@
+---
+title: '第7届区块链EXPO春季展将有10家活用Symbol区块链的企业与团体参展'
+description: '第7届区块链EXPO春季展将有10家活用Symbol区块链的企业与团体参展。'
+createdAt: '2026-04-13T00:00:00Z'
+updatedAt: '2026-04-13T00:00:00Z'
+publishedAt: '2026-04-13T00:00:00Z'
+headerImage: https://github.com/user-attachments/assets/3e91b72d-9f93-457d-9b42-08c0ff70f5bc
+localizations:
+  - id: 550
+    locale: en
+  - id: 551
+    locale: ja-JP
+  - id: 552
+    locale: ko
+  - id: 554
+    locale: zh-Hant-TW
+---
+This page is a machine translation of the English text. Please contact `faunsu https://twitter.com/faunsu19000` or `symbol-community.com/community` for language proofreading of articles.
+
+## 第7届区块链EXPO春季展将有10家活用Symbol区块链的企业与团体参展
+
+<img width="1280" height="720" alt="Image" src="https://github.com/user-attachments/assets/9984ccf0-2de4-4a59-a492-028e55e04eae" />
+
+活动：[第7届区块链EXPO【春】](https://www.nextech-week.jp/hub/ja-jp/visit/bc.html)
+时间：2026年4月15日(周三)至4月17日(周五) 10:00-17:00
+会场：东京Big Sight西展示栋
+到场费用：免费(需提前注册)
+#### 第7届区块链EXPO【春】官网(概要请见此处)
+> [NexTech Week](https://www.nextech-week.jp/hub/ja-jp/visit/bc.html)
+
+#### 到场前注册
+进入区块链EXPO需要免费注册。
+请通过以下URL获取“来场者徽章”后使用。
+
+> URL：https://www.nextech-week.jp/spring/ja-jp/register.html?code=1611458530170798-ENW
+>
+
+在日本最大规模之一、可接触最新区块链技术与服务的活动“NexTech Week 2026 第7届区块链EXPO春季展”上，将由致力于推动区块链技术以及NEM、Symbol区块链技术普及与发展的NPO法人NEM技术普及推进会NEMTUS为核心，联合共计10家开展Symbol相关业务的企业与团体共同参展。
+
+本次参展将集中介绍活用Symbol区块链的企业与团体所提供的产品与服务，全面展示Symbol的技术潜力以及社会落地价值，并探索面向新旧业务导入与合作的机会。
+
+同时还将举办AI・人工智能EXPO、量子计算EXPO、AI时代人才与组织改革EXPO、仿人机器人EXPO，预计这将成为向众多关注最新数字技术的商务人士传达Symbol魅力的绝佳机会。
+
+## 活用Symbol区块链的参展企业与团体
+
+* [NPO法人NEM技术普及推进会NEMTUS](https://nemtus.com)
+* [Atomos-Seed合同会社](https://atomosseed.com)
+* [Food NFT Consortium](https://food-nft.io)
+* [ぶどう株式会社](https://grape.ne.jp)
+* [国立日本综合研究中心株式会社](https://jgrec.jp)
+* [庆成解决方案株式会社](http://keisei-s.co.jp)
+* [HealthCareGate株式会社](https://healthcaregate.co.jp)
+* [Palette Link Okinawa合同会社](https://plo.llc)
+* [Netsujo株式会社](https://netsujo.jp)
+* [关西Healthcare Science Informatics一般社团法人](https://www.khsi.or.jp)
+
+## Symbol的活用案例将出现在案例研讨会中
+
+### Blockchain Case Studies 9
+日期：2026年4月17日(周五) 10:20-11:00
+登坛：[Food NFT Consortium](https://food-nft.io)
+“和食共和国”建国宣言！和食的Web3型流程经济与农大社区
+* 研讨会会场：位于Web3 World区域旁的“Blockchain Case Studies”会场
+
+![Image](https://github.com/user-attachments/assets/494a97bc-7479-48b2-9d84-8b5a6f30773c)
+
+本场将介绍致力于在保存日本独有饮食文化的同时传承至下一代并持续向世界传播的和食Web3型流程经济综合解决方案“和食共和国”，以及作为和食重要构成要素之一的日本农业和持续支撑其发展的农大社区，并邀请专家、一线制作人和社区代表共同分享。
+* “和食共和国”Web3型流程经济综合解决方案的详细解说
+* 日本农业与农大社区的现状与未来
+* “和食共和国”白皮书抢先发放
+
+![Image](https://github.com/user-attachments/assets/db1d62ae-0a03-44ff-880e-cf782cf8dce0)
+
+### 登坛者
+* 后藤博之（主持）
+Food NFT Consortium 共同会长
+Atomos-Seed合同会社 代表
+NPO法人NEM技术普及推进会NEMTUS 理事长
+* 篠原奈央
+自由职业者
+商品开发咨询／企划支持
+原株式会社东鸠商品开发
+CNP(CryptoNinja Partners)社区活动
+* 竹中聪子
+たべもののこえ 和食制作人
+原NHK节目导演
+取得蓝带日本料理文凭
+主导“和食×流程经济”
+* 石川威弘
+农大社区代表
+毕业于东京农业大学
+个人营养师、健康经营顾问
+专家级断食大师
+
+#### 参加“Blockchain Case Studies 9”案例研讨会需要提前注册
+请通过下方URL进入案例研讨会报名网站，并通过“BC-9 Blockchain Case Studies 9”的【选择此研讨会】按钮(橙色按钮)进行报名。
+
+> URL：https://biz.q-pass.jp/f/11988/ntw26sp/seminar_register#seminar111511
+
+### 相关链接
+* [“和食共和国”项目启动｜将和食“过程”价值化的Web3型流程经济](https://symbol-community.com/ja/community/541.html)
+* [“迷你共和国物语”项目启动](https://symbol-community.com/ja/community/546.html)


### PR DESCRIPTION
## Summary
- add a new 5-locale community article set from issue #76
- keep the Japanese article body issue-provided and generate en/ko/zh/zh-hant-tw variants
- publish IDs 550-554 under the community category

## Author gate
- issue author: Radio-Radio (Radio) / 43064866
- authorAssociation: COLLABORATOR
- ymuichiro was already assigned before publish work started

## Locale mapping
- en: 550 -> /community/550
- ja: 551 -> /ja/community/551
- ko: 552 -> /ko/community/552
- zh: 553 -> /zh/community/553
- zh-hant-tw: 554 -> /zh-hant-tw/community/554

## Source handling
- Japanese body text kept from the issue content without rewriting
- issue-provided locales: ja
- auto-translated locales: en, ko, zh, zh-hant-tw

## Validation
- npm --prefix static-site run build ✅
- npm --prefix static-site run test ✅