### PR TITLE
fix(content): publish news articles on top pages

### DIFF
--- a/static-site/content/en/news/402.md
+++ b/static-site/content/en/news/402.md
@@ -1,6 +1,9 @@
 ---
 title: June 2026 Blog (Japanese Translation)
 description: The Japanese translation of The Symbol Syndicate’s Docs Blogs for June 2026
+createdAt: '2026-07-26T16:02:51Z'
+updatedAt: '2026-07-26T16:02:51Z'
+publishedAt: '2026-07-26T16:02:51Z'
 headerImage: ../images/June2026_DocsBlogs_header.webp
 localizations:
   - id: 403

--- a/static-site/content/en/news/407.md
+++ b/static-site/content/en/news/407.md
@@ -1,7 +1,19 @@
 ---
 title: "Mar 2026 The Symbol Syndicate | Anthony’s Engineering Blog"
 description: "Anthony’s Engineering Blog for March 2026"
+createdAt: '2026-08-01T00:34:52Z'
+updatedAt: '2026-08-01T00:34:52Z'
+publishedAt: '2026-08-01T00:34:52Z'
 headerImage: ../images/Anthony_Mar2026_header.jpg
+localizations:
+  - id: 408
+    locale: ko
+  - id: 409
+    locale: zh
+  - id: 410
+    locale: zh-Hant-TW
+  - id: 411
+    locale: ja-JP
 ---
 
 ### Read the March 2026 blog here

--- a/static-site/content/ja/news/406.md
+++ b/static-site/content/ja/news/406.md
@@ -1,6 +1,9 @@
 ---
 title: 2026年6月のブログ（日本語訳）
 description: 2026年6月のThe Symbol Syndicate’s Docs Blogsの日本語訳です
+createdAt: '2026-07-26T16:02:51Z'
+updatedAt: '2026-07-26T16:02:51Z'
+publishedAt: '2026-07-26T16:02:51Z'
 headerImage: ../images/June2026_DocsBlogs_header.webp
 localizations:
   - id: 402

--- a/static-site/content/ja/news/411.md
+++ b/static-site/content/ja/news/411.md
@@ -1,7 +1,19 @@
 ---
 title: "Mar 2026 The Symbol Syndicate | Anthony’s Engineering Blog"
 description: "2026年3月のAnthony’s Engineering Blog"
+createdAt: '2026-08-01T00:34:52Z'
+updatedAt: '2026-08-01T00:34:52Z'
+publishedAt: '2026-08-01T00:34:52Z'
 headerImage: ../images/Anthony_Mar2026_header.jpg
+localizations:
+  - id: 407
+    locale: en
+  - id: 408
+    locale: ko
+  - id: 409
+    locale: zh
+  - id: 410
+    locale: zh-Hant-TW
 ---
 
 ### 2026年3月のブログ（英文）はこちらから

--- a/static-site/content/ko/news/403.md
+++ b/static-site/content/ko/news/403.md
@@ -1,6 +1,9 @@
 ---
 title: 2026년 6월 블로그 (일본어 번역)
 description: 2026년 6월 The Symbol Syndicate Docs Blogs의 일본어 번역입니다
+createdAt: '2026-07-26T16:02:51Z'
+updatedAt: '2026-07-26T16:02:51Z'
+publishedAt: '2026-07-26T16:02:51Z'
 headerImage: ../images/June2026_DocsBlogs_header.webp
 localizations:
   - id: 402

--- a/static-site/content/ko/news/408.md
+++ b/static-site/content/ko/news/408.md
@@ -1,7 +1,19 @@
 ---
 title: "2026년 3월 The Symbol Syndicate | Anthony’s Engineering Blog"
 description: "2026년 3월 Anthony’s Engineering Blog"
+createdAt: '2026-08-01T00:34:52Z'
+updatedAt: '2026-08-01T00:34:52Z'
+publishedAt: '2026-08-01T00:34:52Z'
 headerImage: ../images/Anthony_Mar2026_header.jpg
+localizations:
+  - id: 407
+    locale: en
+  - id: 409
+    locale: zh
+  - id: 410
+    locale: zh-Hant-TW
+  - id: 411
+    locale: ja-JP
 ---
 
 ### 2026년 3월 블로그(영문)는 여기에서 확인할 수 있습니다

--- a/static-site/content/zh-hant-tw/news/405.md
+++ b/static-site/content/zh-hant-tw/news/405.md
@@ -1,6 +1,9 @@
 ---
 title: 2026年6月部落格（日文翻譯）
 description: 2026年6月 The Symbol Syndicate Docs Blogs 的日文翻譯
+createdAt: '2026-07-26T16:02:51Z'
+updatedAt: '2026-07-26T16:02:51Z'
+publishedAt: '2026-07-26T16:02:51Z'
 headerImage: ../images/June2026_DocsBlogs_header.webp
 localizations:
   - id: 402

--- a/static-site/content/zh-hant-tw/news/410.md
+++ b/static-site/content/zh-hant-tw/news/410.md
@@ -1,7 +1,19 @@
 ---
 title: "2026 年 3 月 The Symbol Syndicate | Anthony’s Engineering Blog"
 description: "2026 年 3 月的 Anthony’s Engineering Blog"
+createdAt: '2026-08-01T00:34:52Z'
+updatedAt: '2026-08-01T00:34:52Z'
+publishedAt: '2026-08-01T00:34:52Z'
 headerImage: ../images/Anthony_Mar2026_header.jpg
+localizations:
+  - id: 407
+    locale: en
+  - id: 408
+    locale: ko
+  - id: 409
+    locale: zh
+  - id: 411
+    locale: ja-JP
 ---
 
 ### 2026 年 3 月的英文部落格請見這裡

--- a/static-site/content/zh/news/404.md
+++ b/static-site/content/zh/news/404.md
@@ -1,6 +1,9 @@
 ---
 title: 2026年6月博客（日文翻译）
 description: 2026年6月 The Symbol Syndicate Docs Blogs 的日文翻译
+createdAt: '2026-07-26T16:02:51Z'
+updatedAt: '2026-07-26T16:02:51Z'
+publishedAt: '2026-07-26T16:02:51Z'
 headerImage: ../images/June2026_DocsBlogs_header.webp
 localizations:
   - id: 402

--- a/static-site/content/zh/news/409.md
+++ b/static-site/content/zh/news/409.md
@@ -1,7 +1,19 @@
 ---
 title: "2026年3月 The Symbol Syndicate | Anthony’s Engineering Blog"
 description: "2026年3月的 Anthony’s Engineering Blog"
+createdAt: '2026-08-01T00:34:52Z'
+updatedAt: '2026-08-01T00:34:52Z'
+publishedAt: '2026-08-01T00:34:52Z'
 headerImage: ../images/Anthony_Mar2026_header.jpg
+localizations:
+  - id: 407
+    locale: en
+  - id: 408
+    locale: ko
+  - id: 410
+    locale: zh-Hant-TW
+  - id: 411
+    locale: ja-JP
 ---
 
 ### 2026年3月英文博客请看这里


### PR DESCRIPTION
Summary:
- Added createdAt, updatedAt, and publishedAt to the June 2026 Blog locale set (402-406).
- Added the same publication metadata and complete localizations to the March 2026 Engineering Blog locale set (407-411).
- Preserved all ten article bodies byte-for-byte relative to the parent commit.

Validation:
- npm --prefix static-site run build: passed for all five locales.
- npm --prefix static-site run test: passed, including link and sitemap checks.
- All news articles have valid publishedAt metadata.
- Generated home pages now link to 407/402, 411/406, 408/403, 409/404, and 410/405 for en, ja, ko, zh, and zh-Hant-TW respectively.
- The recurring publication metadata requirement was recorded in the Codex memory notes.