### PR TITLE
fix(css): wrap long article strings safely

### DIFF
--- a/static-site/src/input.css
+++ b/static-site/src/input.css
@@ -763,6 +763,10 @@ img {
   margin-top: 0;
 }
 
+.markdown-body {
+  overflow-wrap: anywhere;
+}
+
 .markdown-body > :last-child {
   margin-bottom: 0;
 }
@@ -823,6 +827,7 @@ img {
   padding: 0.9rem;
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   overflow-x: auto;
+  overflow-wrap: normal;
 }
 
 .markdown-body pre code {


### PR DESCRIPTION
## Summary
- Apply safe overflow wrapping to article body content.
- Preserve horizontal scrolling for fenced code blocks.

## Root cause
Long plain URLs, hashes, and inline code inherited the default wrapping behavior and expanded the page beyond narrow mobile viewports.

## Validation
- `npm --prefix static-site run test`
- Scanned all 374 generated article pages at mobile width: 0 horizontal-overflow pages.
- Verified article 407, long-code article 222, and hash-list article 312.
- Desktop width remains unaffected.