### PR TITLE
fix(css): wrap share actions on narrow screens

### DIFF
--- a/static-site/src/input.css
+++ b/static-site/src/input.css
@@ -646,7 +646,7 @@ img {
 
 .article-share-actions {
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   gap: 0.55rem;
   margin-top: 0.6rem;
   align-items: center;
@@ -976,7 +976,6 @@ img {
 
   .article-share-actions {
     gap: 0.5rem;
-    overflow-x: auto;
     padding-bottom: 0.1rem;
   }
 }


### PR DESCRIPTION
## Summary
- Allow Share this article icons to wrap on narrow screens
- Remove mobile horizontal scrolling that clipped the last icon

## Validation
- npm --prefix static-site run test
- Verified at a 320px mobile viewport: five share actions render across two rows without document overflow